### PR TITLE
Fix Node v10 Date Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .DS_Store
 
 # project
+coverage
 node_modules
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wheniwork-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wheniwork-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A CLI for showing WhenIWork timesheet information.",
   "keywords": [
     "wheniwork",

--- a/src/model/api.service.ts
+++ b/src/model/api.service.ts
@@ -38,7 +38,7 @@ export class ApiService {
     return fetch(
       `${this.url}/times/?user_id=${
         this.storage.userId
-      }&start=${start}&end=${end}`,
+      }&start=${start.toISOString()}&end=${end.toISOString()}`,
       {
         headers: {
           "content-type": "application/json",


### PR DESCRIPTION
Fixes #7

**The Problem**
The CLI was broken because the date wasn't properly passed to the API.

**The Solution**
The new version of Node was calling the date in a new format.  The date values needed to be converted to an ISO string before being called in the query parameter.